### PR TITLE
feat: block user actions over slot if event is not scheduled

### DIFF
--- a/app/Policies/SlotPolicy.php
+++ b/app/Policies/SlotPolicy.php
@@ -41,6 +41,10 @@ class SlotPolicy
         /** @var \App\Models\Event */
         $slotEvent = $slot->event;
 
+        if($slotEvent->status !== 'scheduled') {
+            return Response::deny("Event is not active");
+        }
+
         /** @var \Carbon\Carbon */
         $eventEndDate = $slotEvent->dateEnd;
         $now = Carbon::now();


### PR DESCRIPTION
Implement a new slot policy in order to block actions from user over slot if event is not at **scheduled** status