### PR TITLE
Creates the overlapping endpoint

### DIFF
--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -326,6 +326,29 @@ class SlotController extends Controller
         ]);
     }
 
+    public function listOverlappingSlots($eventId)
+    {
+        $this->authorize('listOverlapping', Slot::class);
+
+        $event = Event::where('id', $eventId)->first();
+
+        $pilots = $event->slots->where('bookingStatus', '!=', 'free')
+                              ->groupBy('pilotId');
+
+        $pilots = $pilots->mapWithKeys( function($slotList, $pilotId) {
+            $slotList = $slotList->reject( function($slotOne) use ($slotList) {
+                foreach($slotList as $slotTwo) {
+                    if($slotOne->id == $slotTwo->id) continue;
+                    return SlotController::checkOverlappingSlots($slotOne, $slotTwo);
+                }
+            });
+
+            return [User::where('id', $pilotId)->first()->vid => $slotList];
+        });
+
+        return $pilots;
+    }
+
     /*
      *  Checks if two slots are overlapping
      */

--- a/app/Policies/SlotPolicy.php
+++ b/app/Policies/SlotPolicy.php
@@ -77,4 +77,13 @@ class SlotPolicy
 
         return true;
     }
+
+    public function listOverlapping(User $user)
+    {
+        if (!$user->admin) {
+            return Response::deny("admin.noAdmin");
+        }
+
+        return true;
+    }
 }

--- a/routes/slots.php
+++ b/routes/slots.php
@@ -21,6 +21,7 @@ $router->group(['middleware' => 'auth', 'prefix' => '/event/{eventId}/slot'], fu
     $router->post('/many', 'SlotController@createMany');
     $router->get('/mine', 'SlotController@getMySlots');
     $router->get('/count', 'SlotController@getEventSlotCountByType');
+    $router->get('/overlapping', 'SlotController@listOverlappingSlots');
 });
 
 $router->group(['middleware' => 'auth', 'prefix' => '/slot'], function () use ($router) {

--- a/storage/app/openapi.json
+++ b/storage/app/openapi.json
@@ -836,6 +836,34 @@
                 }
             }
         },
+        "/event/{eventId}/slot/overlapping": {
+            "get": {
+                "tags": [
+                    "Slot"
+                ],
+                "summary": "Gets a list of booked slots which are overlapping, grouped by pilotid",
+                "security": [
+                    {
+                        "authentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of slots grouped by pilot",
+                        "content": {
+                            "application/json": {
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "User not authenticated"
+                    },
+                    "403": {
+                        "description": "Invalid permissions"
+                    }
+                }
+            }
+        },
         "/slot/{slotId}": {
             "delete": {
                 "summary": "Delete a given slot",


### PR DESCRIPTION
This creates the `/event/{eventid}/slot/overlapping`, which returns a list of slots which are overlapping with each other, grouped by the pilot's VID. 

This will be used to report to our EDs which slots were booked incorrectly before our last fix, and also to validate if any slots were overlapped when a given aircraft did not exist into the system.